### PR TITLE
Use git context for building docker

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -47,7 +47,6 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v4
       with:
-        context: .
         file: src/AskChatGpt/Dockerfile
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Build docker image with git context to see if it enables NBGV to properly burn the assembly version