### PR TITLE
Support using a parent comment for the prompt

### DIFF
--- a/src/AskChatGpt/OpenAIService.cs
+++ b/src/AskChatGpt/OpenAIService.cs
@@ -15,11 +15,13 @@ internal class OpenAIService
 
     public async Task<string> GetChatResponse(string author, string message)
     {
+        const string selfName = "cgptbot";
         var prompt = $"""
+            You are a reddit bot named {selfName}.
             Reply to this reddit comment, giving an insightful answer or witty remark in response.
 
-            {author}: {message}
-              Reply:
+            /u/{author}'s comment: {message}
+              /u/{selfName}'s reply:
             """;
 
         var completionResult = await _openAI.Completions.CreateCompletion(new CompletionCreateRequest()

--- a/src/AskChatGpt/OpenAIService.cs
+++ b/src/AskChatGpt/OpenAIService.cs
@@ -13,14 +13,18 @@ internal class OpenAIService
         _openAI = openAI;
     }
 
-    public async Task<string> GetChatResponse(string author, string message)
+    public async Task<string> GetChatResponse(string author, string message, string? parentAuthor)
     {
         const string selfName = "cgptbot";
         var prompt = $"""
-            You are a reddit bot named {selfName}.
-            Reply to this reddit comment, giving an insightful answer or witty remark in response.
+            Acting as a reddit bot named {selfName}, reply to this comment,
+            giving an insightful answer or witty remark in response.
 
-            /u/{author}'s comment: {message}
+            {(parentAuthor == null ? "" : $"/u/{author} has asked you to comment on /u/{parentAuthor}'s comment above them.")}
+
+            /u/{parentAuthor ?? author}'s comment: {message}
+
+
               /u/{selfName}'s reply:
             """;
 

--- a/src/AskChatGpt/RedditService.cs
+++ b/src/AskChatGpt/RedditService.cs
@@ -68,7 +68,7 @@ internal partial class RedditService
                     // Get prompt from parent comment
                     if (comment.ParentId == null) throw new Exception("No prompt is after the username mention, and no parent comment exists");
 
-                    var parentComment = _reddit.Comment(comment.ParentId).About();
+                    var parentComment = _reddit.Comment($"t1_{comment.ParentId}").About();
                     author = parentComment.Author;
                     promptContext = parentComment.Body;
                     messageText = promptContext;
@@ -80,7 +80,7 @@ internal partial class RedditService
 
                 if (promptContext != null)
                 {
-                    body = $">{promptContext}\n{body}";
+                    body = $">{promptContext}\n\n{body}";
                 }
 
                 _logger.LogInformation("Sending reply to {}:\n------------\n{}\n------------", message.Context, body);


### PR DESCRIPTION
Adds a feature for when no prompt is included in the original comment. Instead, the parent comment will be fetched and used as a prompt.