### PR TITLE
Don't link to anything in signature for spam detection

### DIFF
--- a/src/AskChatGpt/RedditService.cs
+++ b/src/AskChatGpt/RedditService.cs
@@ -21,7 +21,7 @@ internal partial class RedditService
         _signature = $"""
             -----
             AskChatGpt v{versionWithoutBuildMetadata ?? "?"} |
-            [Details & Feedback](https://www.reddit.com/r/AskChatGPTBot/)
+            Details & Feedback - see AskChatGPTBot subreddit
 
             ^(Disclaimer: this uses OpenAI's GPT-3 text completion API; full ChatGPT features are pending API support.)
             """;


### PR DESCRIPTION
Fixes regression from #13 that started the spam filter flagging again